### PR TITLE
Revert to 1_6 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ subprojects { project ->
     version = VERSION_NAME
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_6
+        targetCompatibility = JavaVersion.VERSION_1_6
     }
     
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 GROUP=com.petertackage
-VERSION_NAME=0.8
+VERSION_NAME=0.9


### PR DESCRIPTION
I suspect using 1_8 is causing Android Studio some grief.